### PR TITLE
Improvement/support buster

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,6 +10,10 @@ platforms:
     image: debian:stretch-slim
     groups:
       - debian
+  - name: debian10
+    image: debian:buster-slim
+    groups:
+      - debian
   - name: amazon2018.03
     image: amazonlinux:2018.03
     groups:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -31,7 +31,9 @@ def test_debian_updated(host):
         ).total_seconds() <= 10 * 60
 
 
-def test_redhat_updated(host):
+# This test can fail if there were no updates to install.
+@pytest.mark.xfail
+def test_redhat_updated_time(host):
     """Test that RedHat instances were updated."""
     ansible_vars = host.ansible.get_variables()
     if ansible_vars["inventory_hostname"] in ansible_vars["groups"]["amazon"]:
@@ -44,3 +46,12 @@ def test_redhat_updated(host):
         # Make sure that the instance was updated in the last 10
         # minutes
         assert (datetime.datetime.now() - last_update).total_seconds() <= 10 * 60
+
+
+def test_redhat_updated_command_output(host):
+    """Test that RedHat instances were updated."""
+    ansible_vars = host.ansible.get_variables()
+    if ansible_vars["inventory_hostname"] in ansible_vars["groups"]["amazon"]:
+        yum_output = host.run("yum update")
+        # If the update succeeded or there was nothing to update
+        assert "No packages marked for update" in yum_output.stdout


### PR DESCRIPTION
Add support for buster. 
Fix a redhat test that fails when there are no updates available.  (newish amazon image).
