### PR TITLE
Add kali distro

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,6 +18,8 @@ platforms:
     image: amazonlinux:2018.03
     groups:
       - amazon
+  - name: bootstrap-kali
+    image: kalilinux/kali-linux-docker
 provisioner:
   name: ansible
   lint:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,11 +33,7 @@
 
 - name: Upgrade Kali packages
   apt:
-    name: '*'
-    # ansible-lint generates a warning that "package installs should
-    # not use latest" here, but this is one place where we want to use
-    # it.
-    state: latest  # noqa 403
+    upgrade: dist
     update_cache: yes
     cache_valid_time: 3600
     # Because the cache was updated for cryptsetup don't update the cache if

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,13 +26,13 @@
   when: ansible_distribution_release == "kali-rolling"
 
 - name: apt-get update
-  shell: apt-get update # noqa 303 305
+  shell: apt-get update  # noqa 303 305
   when: ansible_distribution_release == "kali-rolling"
 
 # Upgrading with shell command instead of apt ansible module
 # See https://github.com/ansible/ansible/issues/63134 for more info
 - name: Upgrade with noninteractive frontend to handle GUI prompts
-  shell: apt-get -yy upgrade # noqa 303 305
+  shell: apt-get -yy upgrade  # noqa 303 305
   when: ansible_distribution_release == "kali-rolling"
   environment:
     DEBIAN_FRONTEND: noninteractive

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,33 +18,38 @@
     ansible_os_family == "Debian" and
     ansible_distribution_release != "kali-rolling"
 
-- name: Reinstall cryptsetup-initramfs so upgrade doesn't fail
-  apt:
-    name: 'cryptsetup-initramfs'
-    update_cache: yes
-  when: ansible_distribution_release == "kali-rolling"
+# Kali linux is a special case, since the usual Debian foo doesn't
+# seem to work for it
+- name: Kali-specific tasks
+  block:
+    - name: apt-get update
+      command: apt-get update
+      args:
+        warn: false
+      # Ignore idempotence test because apt-get update cannot
+      # guarantee idempotence
+      tags:
+        - molecule-idempotence-notest
 
-- name: apt-get update
-  command: apt-get update
-  args:
-    warn: false
-  when: ansible_distribution_release == "kali-rolling"
-  # ignore idempotence test because apt-get update cannot guarantee
-  # idempotence compliance
-  tags: molecule-idempotence-notest
+    - name: Reinstall cryptsetup-initramfs so upgrade doesn't fail
+      apt:
+        name: 'cryptsetup-initramfs'
 
-# Upgrading with command module instead of apt ansible module
-# See https://github.com/ansible/ansible/issues/63134 for more info
-- name: Upgrade with noninteractive frontend to handle GUI prompts
-  command: apt-get -yy upgrade
+    # Upgrade with command module instead of apt ansible module
+    #
+    # See https://github.com/ansible/ansible/issues/63134 for more
+    # info
+    - name: Upgrade with noninteractive frontend to handle GUI prompts
+      command: apt-get -yy upgrade
+      args:
+        warn: false
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+      # Ignore idempotence test because apt-get upgrade cannot
+      # guarantee idempotence
+      tags:
+        - molecule-idempotence-notest
   when: ansible_distribution_release == "kali-rolling"
-  args:
-    warn: false
-  environment:
-    DEBIAN_FRONTEND: noninteractive
-  # ignore idempotence test because apt-get upgrade cannot guarantee
-  # idempotence compliance
-  tags: molecule-idempotence-notest
 
 - name: Upgrade all RedHat packages
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,10 +21,6 @@
 - name: Reinstall cryptsetup-initramfs so upgrade doesn't fail
   apt:
     name: 'cryptsetup-initramfs'
-    # ansible-lint generates a warning that "package installs should
-    # not use latest" here, but this is one place where we want to use
-    # it.
-    state: latest  # noqa 403
     update_cache: yes
   when: ansible_distribution_release == "kali-rolling"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
   args:
     warn: false
   when: ansible_distribution_release == "kali-rolling"
-  # ignore idempotence test because apt-get update cannot guuarantee
+  # ignore idempotence test because apt-get update cannot guarantee
   # idempotence compliant
   tags: molecule-idempotence-notest
 
@@ -51,7 +51,7 @@
     warn: false
   environment:
     DEBIAN_FRONTEND: noninteractive
-  # ignore idempotence test because apt-get upgrade cannot guuarantee
+  # ignore idempotence test because apt-get upgrade cannot guarantee
   # idempotence compliant
   tags: molecule-idempotence-notest
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,20 +25,17 @@
     update_cache: yes
   when: ansible_distribution_release == "kali-rolling"
 
-# - name: Upgrade with noninteractive frontend to handle GUI prompts
-#   shell: apt-get -yy upgrade
-#   when: ansible_distribution_release == "kali-rolling"
-#   environment:
-#     DEBIAN_FRONTEND: noninteractive
-
-- name: Upgrade Kali packages
-  apt:
-    upgrade: yes
-    update_cache: yes
-    cache_valid_time: 3600
-    # Because the cache was updated for cryptsetup don't update the cache if
-    # it has been less that 60 minutes
+- name: apt-get update
+  shell: apt-get update
   when: ansible_distribution_release == "kali-rolling"
+
+# Upgrading with shell command instead of apt ansible module
+# See https://github.com/ansible/ansible/issues/63134 for more info
+- name: Upgrade with noninteractive frontend to handle GUI prompts
+  shell: apt-get -yy upgrade
+  when: ansible_distribution_release == "kali-rolling"
+  environment:
+    DEBIAN_FRONTEND: noninteractive
 
 - name: Upgrade all RedHat packages
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   shell: apt-get -yy upgrade
   when: ansible_distribution_release == "kali-rolling"
   environment:
-    DEBIAN_FRONTEND: "noninteractive"
+    DEBIAN_FRONTEND: noninteractive
 
 - name: Upgrade all Kali packages
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,32 +6,6 @@
     force_apt_get: yes
   when: ansible_os_family == "Debian"
 
-- name: Reinstall cryptsetup-initramfs so upgrade doesn't fail
-  apt:
-    name: 'cryptsetup-initramfs'
-    state: latest  # noqa 403
-    update_cache: yes
-  when: ansible_distribution_release == "kali-rolling"
-
-- name: Upgrade all packages for Kali and get around GUI prompts with environment variable
-  apt:
-    name: '*'
-    state: latest  # noqa 403
-    update_cache: yes
-  when: ansible_distribution_release == "kali-rolling"
-  environment:
-    DEBIAN_FRONTEND: noninteractive
-
-- name: Upgrade all Kali packages
-  apt:
-    name: '*'
-    # ansible-lint generates a warning that "package installs should
-    # not use latest" here, but this is one place where we want to use
-    # it.
-    state: latest  # noqa 403
-    update_cache: yes
-  when: ansible_os_family == "RedHat"
-
 - name: Upgrade all Debian packages
   apt:
     name: '*'
@@ -40,7 +14,28 @@
     # it.
     state: latest  # noqa 403
     update_cache: yes
-  when: ansible_os_family == "Debian" and ansible_distribution_release != "kali-rolling"
+  when: >
+    ansible_os_family == "Debian" and
+    ansible_distribution_release != "kali-rolling"
+
+- name: Reinstall cryptsetup-initramfs so upgrade doesn't fail
+  apt:
+    name: 'cryptsetup-initramfs'
+    state: latest  # noqa 403
+    update_cache: yes
+  when: ansible_distribution_release == "kali-rolling"
+
+- name: Upgrade Kali packages/get around GUI prompts with environment variable
+  apt:
+    name: '*'
+    # ansible-lint generates a warning that "package installs should
+    # not use latest" here, but this is one place where we want to use
+    # it.
+    state: latest  # noqa 403
+    update_cache: yes
+  when: ansible_distribution_release == "kali-rolling"
+  environment:
+    DEBIAN_FRONTEND: noninteractive
 
 - name: Upgrade all RedHat packages
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     warn: false
   environment:
     DEBIAN_FRONTEND: noninteractive
-  # ignore idempotence test because apt-get upgrade cannot guuarantee
+  # ignore idempotence test because apt-get upgrade cannot guarantee
   # idempotence compliance
   tags: molecule-idempotence-notest
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
 
 - name: apt-get update
   shell: apt-get update  # noqa 303 305
+  warn: false
   when: ansible_distribution_release == "kali-rolling"
 
 # Upgrading with shell command instead of apt ansible module
@@ -34,6 +35,7 @@
 - name: Upgrade with noninteractive frontend to handle GUI prompts
   shell: apt-get -yy upgrade  # noqa 303 305
   when: ansible_distribution_release == "kali-rolling"
+  warn: false
   environment:
     DEBIAN_FRONTEND: noninteractive
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,18 +25,24 @@
     update_cache: yes
   when: ansible_distribution_release == "kali-rolling"
 
-- name: Upgrade Kali packages/get around GUI prompts with environment variable
-  apt:
-    name: '*'
-    # ansible-lint generates a warning that "package installs should
-    # not use latest" here, but this is one place where we want to use
-    # it.
-    state: latest  # noqa 403
-    update_cache: yes
+- name: Upgrade with noninteractive frontend to handle GUI prompts
+  shell: apt-get -yy upgrade
   when: ansible_distribution_release == "kali-rolling"
   environment:
     DEBIAN_FRONTEND: noninteractive
 
+# - name: Upgrade Kali packages/get around GUI prompts with environment variable
+#   apt:
+#     name: '*'
+#     # ansible-lint generates a warning that "package installs should
+#     # not use latest" here, but this is one place where we want to use
+#     # it.
+#     state: latest  # noqa 403
+#     update_cache: yes
+#   when: ansible_distribution_release == "kali-rolling"
+#   environment:
+#     DEBIAN_FRONTEND: noninteractive
+# 
 - name: Upgrade all RedHat packages
   yum:
     name: '*'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     force_apt_get: yes
   when: ansible_os_family == "Debian"
 
-- name: reinstall cryptsetup-initramfs to fix upgrade
+- name: apt-get update
   shell: apt-get update
   when: ansible_distribution_release == "kali-rolling"
 
@@ -14,7 +14,7 @@
   shell: apt-get install --reinstall cryptsetup-initramfs -y
   when: ansible_distribution_release == "kali-rolling"
 
-- name: reinstall cryptsetup-initramfs to fix upgrade
+- name: Upgrade with noninteractive frontend to handle GUI prompts
   shell: DEBIAN_FRONTEND=noninteractive apt-get -yy upgrade
   when: ansible_distribution_release == "kali-rolling"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,9 @@
 - name: reinstall cryptsetup-initramfs to fix upgrade
   shell: apt-get update
   when: ansible_distribution_release == "kali-rolling"
-  
+
 - name: reinstall cryptsetup-initramfs to fix upgrade
-  shell: apt-get install --reinstall cryptsetup-initramfs
+  shell: apt-get install --reinstall cryptsetup-initramfs -y
   when: ansible_distribution_release == "kali-rolling"
 
 - name: reinstall cryptsetup-initramfs to fix upgrade

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,8 +15,10 @@
   when: ansible_distribution_release == "kali-rolling"
 
 - name: Upgrade with noninteractive frontend to handle GUI prompts
-  shell: DEBIAN_FRONTEND=noninteractive apt-get -yy upgrade
+  shell: apt-get -yy upgrade
   when: ansible_distribution_release == "kali-rolling"
+  environment:
+    DEBIAN_FRONTEND: "noninteractive"
 
 - name: Upgrade all Kali packages
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,20 +26,22 @@
   when: ansible_distribution_release == "kali-rolling"
 
 - name: apt-get update
-  shell: apt-get update  # noqa 303 305 molecule-idempotence-notest
+  shell: apt-get update  # noqa 303 305
   args:
     warn: false
   when: ansible_distribution_release == "kali-rolling"
+  tags: molecule-idempotence-notest
 
 # Upgrading with shell command instead of apt ansible module
 # See https://github.com/ansible/ansible/issues/63134 for more info
 - name: Upgrade with noninteractive frontend to handle GUI prompts
-  shell: apt-get -yy upgrade  # noqa 303 305 molecule-idempotence-notest
+  shell: apt-get -yy upgrade  # noqa 303 305
   when: ansible_distribution_release == "kali-rolling"
   args:
     warn: false
   environment:
     DEBIAN_FRONTEND: noninteractive
+  tags: molecule-idempotence-notest
 
 - name: Upgrade all RedHat packages
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,11 +7,11 @@
   when: ansible_os_family == "Debian"
 
 - name: reinstall cryptsetup-initramfs to fix upgrade
-  shell: apt-get install --reinstall cryptsetup-initramfs
-  when: ansible_distribution_release == "kali-rolling"
-
-- name: reinstall cryptsetup-initramfs to fix upgrade
   shell: apt-get update
+  when: ansible_distribution_release == "kali-rolling"
+  
+- name: reinstall cryptsetup-initramfs to fix upgrade
+  shell: apt-get install --reinstall cryptsetup-initramfs
   when: ansible_distribution_release == "kali-rolling"
 
 - name: reinstall cryptsetup-initramfs to fix upgrade

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,16 +6,18 @@
     force_apt_get: yes
   when: ansible_os_family == "Debian"
 
-- name: apt-get update
-  shell: apt-get update
+- name: Reinstall cryptsetup-initramfs so upgrade doesn't fail
+  apt:
+    name: 'cryptsetup-initramfs'
+    state: latest  # noqa 403
+    update_cache: yes
   when: ansible_distribution_release == "kali-rolling"
 
-- name: reinstall cryptsetup-initramfs to fix upgrade
-  shell: apt-get install --reinstall cryptsetup-initramfs -y
-  when: ansible_distribution_release == "kali-rolling"
-
-- name: Upgrade with noninteractive frontend to handle GUI prompts
-  shell: apt-get -yy upgrade
+- name: Upgrade all packages for Kali and get around GUI prompts with environment variable
+  apt:
+    name: '*'
+    state: latest  # noqa 403
+    update_cache: yes
   when: ansible_distribution_release == "kali-rolling"
   environment:
     DEBIAN_FRONTEND: noninteractive

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,26 +21,38 @@
 - name: Reinstall cryptsetup-initramfs so upgrade doesn't fail
   apt:
     name: 'cryptsetup-initramfs'
+    # ansible-lint generates a warning that "package installs should
+    # not use latest" here, but this is one place where we want to use
+    # it.
     state: latest  # noqa 403
     update_cache: yes
   when: ansible_distribution_release == "kali-rolling"
 
 - name: apt-get update
+  # ansible-lint generates a warning when using shell apt over the
+  # ansible apt module, but we want to use the shell. See upgrade below
   shell: apt-get update  # noqa 303 305
   args:
     warn: false
   when: ansible_distribution_release == "kali-rolling"
+  # ignore idempotence test because apt-get update cannot guuarantee
+  # idempotence compliant
   tags: molecule-idempotence-notest
 
 # Upgrading with shell command instead of apt ansible module
 # See https://github.com/ansible/ansible/issues/63134 for more info
 - name: Upgrade with noninteractive frontend to handle GUI prompts
+  # ansible-lint generates a warning when using shell apt over the
+  # ansible apt module, but we want to use the shell. The ansible apt module
+  # hangs for this distribution
   shell: apt-get -yy upgrade  # noqa 303 305
   when: ansible_distribution_release == "kali-rolling"
   args:
     warn: false
   environment:
     DEBIAN_FRONTEND: noninteractive
+  # ignore idempotence test because apt-get upgrade cannot guuarantee
+  # idempotence compliant
   tags: molecule-idempotence-notest
 
 - name: Upgrade all RedHat packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,28 @@
     force_apt_get: yes
   when: ansible_os_family == "Debian"
 
+- name: reinstall cryptsetup-initramfs to fix upgrade
+  shell: apt-get install --reinstall cryptsetup-initramfs
+  when: ansible_distribution_release == "kali-rolling"
+
+- name: reinstall cryptsetup-initramfs to fix upgrade
+  shell: apt-get update
+  when: ansible_distribution_release == "kali-rolling"
+
+- name: reinstall cryptsetup-initramfs to fix upgrade
+  shell: DEBIAN_FRONTEND=noninteractive apt-get -yy upgrade
+  when: ansible_distribution_release == "kali-rolling"
+
+- name: Upgrade all Kali packages
+  apt:
+    name: '*'
+    # ansible-lint generates a warning that "package installs should
+    # not use latest" here, but this is one place where we want to use
+    # it.
+    state: latest  # noqa 403
+    update_cache: yes
+  when: ansible_os_family == "RedHat"
+
 - name: Upgrade all Debian packages
   apt:
     name: '*'
@@ -14,7 +36,7 @@
     # it.
     state: latest  # noqa 403
     update_cache: yes
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" and ansible_distribution_release != "kali-rolling"
 
 - name: Upgrade all RedHat packages
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,13 +26,13 @@
   when: ansible_distribution_release == "kali-rolling"
 
 - name: apt-get update
-  shell: apt-get update
+  shell: apt-get update # noqa 303 305
   when: ansible_distribution_release == "kali-rolling"
 
 # Upgrading with shell command instead of apt ansible module
 # See https://github.com/ansible/ansible/issues/63134 for more info
 - name: Upgrade with noninteractive frontend to handle GUI prompts
-  shell: apt-get -yy upgrade
+  shell: apt-get -yy upgrade # noqa 303 305
   when: ansible_distribution_release == "kali-rolling"
   environment:
     DEBIAN_FRONTEND: noninteractive

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Upgrade Kali packages
   apt:
-    upgrade: dist
+    upgrade: yes
     update_cache: yes
     cache_valid_time: 3600
     # Because the cache was updated for cryptsetup don't update the cache if

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
   when: ansible_distribution_release == "kali-rolling"
 
 - name: apt-get update
-  shell: apt-get update  # noqa 303 305
+  shell: apt-get update  # noqa 303 305 molecule-idempotence-notest
   args:
     warn: false
   when: ansible_distribution_release == "kali-rolling"
@@ -34,7 +34,7 @@
 # Upgrading with shell command instead of apt ansible module
 # See https://github.com/ansible/ansible/issues/63134 for more info
 - name: Upgrade with noninteractive frontend to handle GUI prompts
-  shell: apt-get -yy upgrade  # noqa 303 305
+  shell: apt-get -yy upgrade  # noqa 303 305 molecule-idempotence-notest
   when: ansible_distribution_release == "kali-rolling"
   args:
     warn: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,8 @@
 
 - name: apt-get update
   shell: apt-get update  # noqa 303 305
-  warn: false
+  args:
+    warn: false
   when: ansible_distribution_release == "kali-rolling"
 
 # Upgrading with shell command instead of apt ansible module
@@ -35,7 +36,8 @@
 - name: Upgrade with noninteractive frontend to handle GUI prompts
   shell: apt-get -yy upgrade  # noqa 303 305
   when: ansible_distribution_release == "kali-rolling"
-  warn: false
+  args:
+    warn: false
   environment:
     DEBIAN_FRONTEND: noninteractive
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,9 +25,7 @@
   when: ansible_distribution_release == "kali-rolling"
 
 - name: apt-get update
-  # ansible-lint generates a warning when using shell apt over the
-  # ansible apt module, but we want to use the shell. See upgrade below
-  shell: apt-get update  # noqa 303 305
+  command: apt-get update
   args:
     warn: false
   when: ansible_distribution_release == "kali-rolling"
@@ -35,13 +33,10 @@
   # idempotence compliant
   tags: molecule-idempotence-notest
 
-# Upgrading with shell command instead of apt ansible module
+# Upgrading with command module instead of apt ansible module
 # See https://github.com/ansible/ansible/issues/63134 for more info
 - name: Upgrade with noninteractive frontend to handle GUI prompts
-  # ansible-lint generates a warning when using shell apt over the
-  # ansible apt module, but we want to use the shell. The ansible apt module
-  # hangs for this distribution
-  shell: apt-get -yy upgrade  # noqa 303 305
+  command: apt-get -yy upgrade
   when: ansible_distribution_release == "kali-rolling"
   args:
     warn: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,8 +29,8 @@
   args:
     warn: false
   when: ansible_distribution_release == "kali-rolling"
-  # ignore idempotence test because apt-get update cannot guuarantee
-  # idempotence compliant
+  # ignore idempotence test because apt-get update cannot guarantee
+  # idempotence compliance
   tags: molecule-idempotence-notest
 
 # Upgrading with command module instead of apt ansible module
@@ -43,7 +43,7 @@
   environment:
     DEBIAN_FRONTEND: noninteractive
   # ignore idempotence test because apt-get upgrade cannot guuarantee
-  # idempotence compliant
+  # idempotence compliance
   tags: molecule-idempotence-notest
 
 - name: Upgrade all RedHat packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,24 +25,25 @@
     update_cache: yes
   when: ansible_distribution_release == "kali-rolling"
 
-- name: Upgrade with noninteractive frontend to handle GUI prompts
-  shell: apt-get -yy upgrade
-  when: ansible_distribution_release == "kali-rolling"
-  environment:
-    DEBIAN_FRONTEND: noninteractive
-
-# - name: Upgrade Kali packages/get around GUI prompts with environment variable
-#   apt:
-#     name: '*'
-#     # ansible-lint generates a warning that "package installs should
-#     # not use latest" here, but this is one place where we want to use
-#     # it.
-#     state: latest  # noqa 403
-#     update_cache: yes
+# - name: Upgrade with noninteractive frontend to handle GUI prompts
+#   shell: apt-get -yy upgrade
 #   when: ansible_distribution_release == "kali-rolling"
 #   environment:
 #     DEBIAN_FRONTEND: noninteractive
-# 
+
+- name: Upgrade Kali packages
+  apt:
+    name: '*'
+    # ansible-lint generates a warning that "package installs should
+    # not use latest" here, but this is one place where we want to use
+    # it.
+    state: latest  # noqa 403
+    update_cache: yes
+    cache_valid_time: 3600
+    # Because the cache was updated for cryptsetup don't update the cache if
+    # it has been less that 60 minutes
+  when: ansible_distribution_release == "kali-rolling"
+
 - name: Upgrade all RedHat packages
   yum:
     name: '*'


### PR DESCRIPTION
Add Kali distro to upgrade by using shell commands instead of ansible apt module due to a bug causing the apt module to hang and never complete. 