### PR TITLE
ignore changes in conf files and update cryptsetup to latest package

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,5 @@
+# Force ansible-lint to be a pre-release version temporarily
+ansible-lint==4.1.1a3
 docker # Needed for molecule to work correctly
 molecule
 pre-commit

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 # Force ansible-lint to be a pre-release version temporarily
 # https://github.com/ansible/ansible-lint/issues/484 fixed bug
-# in ansible-lint noqa within block. Require pre-realse with bug fix
+# in ansible-lint noqa within block. Require pre-release with bug fix
 ansible-lint==4.1.1a3
 docker # Needed for molecule to work correctly
 molecule

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,6 @@
 # Force ansible-lint to be a pre-release version temporarily
+# https://github.com/ansible/ansible-lint/issues/484 fixed bug
+# in ansible-lint noqa within block. Require pre-realse with bug fix
 ansible-lint==4.1.1a3
 docker # Needed for molecule to work correctly
 molecule

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,10 @@
     - name: Reinstall cryptsetup-initramfs so upgrade doesn't fail
       apt:
         name: 'cryptsetup-initramfs'
-        state: latest
+        # ansible-lint generates a warning that "package installs should
+        # not use latest" here, but this is one place where we want to use
+        # it.
+        state: latest  # noqa 403
 
     # Upgrade with command module instead of apt ansible module
     # and ignore configuration file changes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,16 +31,20 @@
       tags:
         - molecule-idempotence-notest
 
+    # The lastest cryptsetup-initramfs is needed to fix upgrade
     - name: Reinstall cryptsetup-initramfs so upgrade doesn't fail
       apt:
         name: 'cryptsetup-initramfs'
+        state: latest
 
     # Upgrade with command module instead of apt ansible module
-    #
+    # and ignore configuration file changes
     # See https://github.com/ansible/ansible/issues/63134 for more
     # info
     - name: Upgrade with noninteractive frontend to handle GUI prompts
-      command: apt-get -yy upgrade
+      command: >
+        apt-get -yy -o Dpkg::Options::="--force-confdef"
+        -o Dpkg::Options::="--force-confold" upgrade
       args:
         warn: false
       environment:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,8 @@
         state: latest  # noqa 403
 
     # Upgrade with command module instead of apt ansible module
-    # and ignore configuration file changes
+    # and ignore configuration file changes just like
+    # ansible apt dpkg_options default behavior
     # See https://github.com/ansible/ansible/issues/63134 for more
     # info
     - name: Upgrade with noninteractive frontend to handle GUI prompts


### PR DESCRIPTION
cryptsetup-initramfs must have the latest version to not break the upgrade process. `Dpkg::Options::="--force-confdef"-o Dpkg::Options::="--force-confold"` was added to ignore changes in configuration files that have changed (e.g. the cloud init config file `cloud.cfg`)