### PR TITLE
Update cache in the first apt module call

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -5,7 +5,7 @@
   apt:
     name: 'aptitude'
     force_apt_get: yes
+    update_cache: yes
 - name: Upgrade all packages (Debian)
   apt:
     upgrade: dist
-    update_cache: yes


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This pull request forces a cache update in the first usage Ansible `apt` module.  Otherwise the first usage of `apt` can fail if there is no preexisting cache.

## 💭 Motivation and Context

The Kali Linux base AMI we are using in the COOL has no cache at all, so we must update the cache the first time we use the Ansible `apt` module.  It also just makes good sense to do so.

## 🧪 Testing

I was able to build a new Kali AMI for the COOL with these changes.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
