### PR TITLE
Pin debian kernel

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,6 +1,0 @@
----
-- name: Import upgrade playbook
-  import_playbook: upgrade.yml
-
-- name: Import python playbook
-  import_playbook: python.yml

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,9 +1,0 @@
----
-- hosts: all
-  name: Install pip3/python3 and remove pip2/python2
-  become: yes
-  become_method: sudo
-  roles:
-    - pip
-    - python
-    - remove_python2

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -13,6 +13,20 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
+def test_debian_kernel_held(host):
+    """Test that Debian kernel is held."""
+    if (
+        host.system_info.distribution == "debian"
+        and host.system_info.codename == "buster"
+    ):
+        assert set(host.file("/boot").listdir()) == {
+            "System.map-4.19.0-9-cloud-amd64",
+            "config-4.19.0-9-cloud-amd64",
+            "initrd.img-4.19.0-9-cloud-amd64",
+            "vmlinuz-4.19.0-9-cloud-amd64",
+        }
+
+
 @pytest.mark.parametrize("pkg", ["aptitude"])
 def test_debian_packages(host, pkg):
     """Test that appropriate packages were installed on Debian."""

--- a/molecule/default/upgrade.yml
+++ b/molecule/default/upgrade.yml
@@ -1,7 +1,0 @@
----
-- hosts: all
-  name: Upgrade base image
-  become: yes
-  become_method: sudo
-  roles:
-    - upgrade

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,7 +3,7 @@
 
 - name: Install aptitude (Debian)
   apt:
-    name: 'aptitude'
+    name: aptitude
     force_apt_get: yes
     update_cache: yes
 - name: Upgrade all packages (Debian)

--- a/tasks/Debian_10_hold_kernel.yml
+++ b/tasks/Debian_10_hold_kernel.yml
@@ -1,0 +1,29 @@
+---
+- name: Install aptitude (Debian)
+  apt:
+    name: aptitude
+    force_apt_get: yes
+    update_cache: yes
+
+# On Debian, the 4.19.132-1 kernel is randomly locking up on us, while
+# the 4.19.118-2 kernel worked just fine.  Until we can determine the
+# exact reason for the failure and verify that it has been fixed, we
+# will install the 4.19.118-2 kernel and hold that package.
+- name: Remove current kernel (Debian)
+  apt:
+    name:
+      - linux-headers-cloud-amd64
+      - linux-image-cloud-amd64
+    state: absent
+- name: Install specific version of kernel (Debian)
+  apt:
+    name:
+      - linux-headers-4.19.0-9-cloud-amd64
+      - linux-image-4.19.0-9-cloud-amd64
+- name: Hold the kernel so that it is not upgrades via apt-get upgrade
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop:
+    - linux-headers-4.19.0-9-cloud-amd64
+    - linux-image-4.19.0-9-cloud-amd64

--- a/tasks/Debian_10_hold_kernel.yml
+++ b/tasks/Debian_10_hold_kernel.yml
@@ -22,7 +22,7 @@
     name:
       - linux-headers-4.19.0-9-cloud-amd64
       - linux-image-4.19.0-9-cloud-amd64
-- name: Hold the kernel so that it is not upgrades via apt-get upgrade
+- name: Hold the kernel so that it is not upgraded via apt-get upgrade
   dpkg_selections:
     name: "{{ item }}"
     selection: hold

--- a/tasks/Debian_10_hold_kernel.yml
+++ b/tasks/Debian_10_hold_kernel.yml
@@ -15,6 +15,8 @@
       - linux-headers-cloud-amd64
       - linux-image-cloud-amd64
     state: absent
+  tags:
+    - molecule-idempotence-notest
 - name: Install specific version of kernel (Debian)
   apt:
     name:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,20 @@
 ---
 # tasks file for upgrade
 
+# On Debian 10, the 4.19.132-1 kernel is randomly locking up on us,
+# while the 4.19.118-2 kernel worked just fine.  Until we can
+# determine the exact reason for the failure and verify that it has
+# been fixed, we will install the 4.19.118-2 kernel and hold that
+# package.
+#
+# Note that this is done _only_ for version 10 of the Debian
+# distribution and not for other distributions in the Debian family.
+- name: Hold kernel for Debian distribution
+  include: Debian_10_hold_kernel.yml
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_distribution_version == "10"
+
 - name: Load tasks file with install tasks based on the OS type
   include: "{{ lookup('first_found', params) }}"
   vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
         # Add regex_replace() filters to remove spaces and
         # slashes. This allows the OS family/distribution for Kali,
         # "Kali GNU/Linux", to be easily mapped to a vars file.
+        - "{{ ansible_distribution | regex_replace('[ /]', '_') }}_{{ ansible_distribution_version }}.yml"
         - "{{ ansible_distribution | regex_replace('[ /]', '_') }}.yml"
         - "{{ ansible_os_family | regex_replace('[ /]', '_') }}.yml"
       paths:


### PR DESCRIPTION
## 🗣 Description

This PR pins the kernel for the Debian distribution to version `linux-image-4.19.0-9-cloud-amd64`.

## 💭 Motivation and Context

I generated a Guacamole AMIs for [production](https://github.com/cisagov/guacamole-packer/releases/tag/v0.1.3) and [staging](https://github.com/cisagov/guacamole-packer/releases/tag/v0.1.3-rc.2) late last week.  @dav3r and I have been seeing those instances randomly lock up.  We believe that this is because they are Debian images running with the linux kernel package `linux-image-4.19.0-10-cloud-amd64` (`4.19.0-10-cloud-amd64 #1 SMP Debian 4.19.132-1 (2020-07-24) x86_64`), while the last known good AMIs were running `linux-image-4.19.0-9-cloud-amd64` (`4.19.0-9-cloud-amd64 #1 SMP Debian 4.19.118-2+deb10u1 (2020-06-07) x86_64`).

There are a number of online reports of a recent kernel change causing such behavior, e.g. [here](https://forum.proxmox.com/threads/kernel-5-4-44-causes-system-freeze-on-hp-microserver-gen8.72050/) and [here](https://lkml.org/lkml/2020/7/20/883).  The problematic change is [confirmed to be in the Debian `linux-image-4.19.0-10-cloud-amd64` package](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966846).

I have manually set up env1 in staging and env4 in production to save a `kdump` if they encounter a kernel panic.  That should allow us to determine for certain whether the kernel issue referred to above is indeed the culprit the next time one of those instances locks up.

## 🧪 Testing

All molecule tests and pre-commit hooks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
