### PR TITLE
Remove existing kernels for Debian 10

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+# On Debian 10, the 4.19.132-1 kernel is randomly locking up on us,
+# while the 4.19.118-2 kernel worked just fine.  Until we can
+# determine the exact reason for the failure and verify that it has
+# been fixed, we will install the 4.19.118-2 kernel and hold that
+# package.
+#
+# To make a better test platform, we go ahead and install the latest
+# kernel for Debian 10.  The base image we use to build our AWS AMIs
+# already has a kernel installed, so this will allow us to confirm
+# that it gets removed in our molecule tests.
+- name: Group hosts by OS distribution
+  hosts: all
+  tasks:
+    - name: Group hosts by OS distribution
+      group_by:
+        key: os_{{ ansible_distribution }}_{{ ansible_distribution_version }}
+- name: Wait for systemd to complete initialization (Debian)
+  hosts: os_Debian_10
+  tasks:
+    - name: Install aptitude (Debian 10)
+      apt:
+        name: aptitude
+        force_apt_get: yes
+        update_cache: yes
+    - name: Install the latest kernel (Debian 10)
+      apt:
+        name:
+          - linux-headers-cloud-amd64
+          - linux-image-cloud-amd64

--- a/tasks/Debian_10_hold_kernel.yml
+++ b/tasks/Debian_10_hold_kernel.yml
@@ -9,11 +9,11 @@
 # the 4.19.118-2 kernel worked just fine.  Until we can determine the
 # exact reason for the failure and verify that it has been fixed, we
 # will install the 4.19.118-2 kernel and hold that package.
-- name: Remove current kernel (Debian)
+- name: Remove all installed kernels (Debian)
   apt:
     name:
-      - linux-headers-cloud-amd64
-      - linux-image-cloud-amd64
+      - linux-headers-*
+      - linux-image-*
     state: absent
   tags:
     - molecule-idempotence-notest


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Changes the Ansible role to remove all existing kernels before installing the desired one (Debian 10 only)
* Installs the latest kernel in the prepare playbook (Debian 10 only)

## 💭 Motivation and Context

When I created a Debian 10 Guacamole AMI after merging #11, @dav3r found that it was still running the latest kernel.  Upon investigation, I found that the latest kernel _and_ the desired one were both installed.  That is why I am changing the Ansible role to first remove all existing kernels before installing the desired one.

The Debian 10 Docker image where we run our molecule tests comes to us with no kernel installed, of course.  That is why the molecule tests passed for #11.  Therefore I added a prepare playbook that installs the latest kernel for Debian 10, which allows to better test that _only_ the desired kernel is installed when all is said and done.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
