### PR TITLE
Do not remove all kernel headers

### DIFF
--- a/tasks/Debian_10_hold_kernel.yml
+++ b/tasks/Debian_10_hold_kernel.yml
@@ -12,7 +12,6 @@
 - name: Remove all installed kernels (Debian)
   apt:
     name:
-      - linux-headers-*
       - linux-image-*
     state: absent
   tags:


### PR DESCRIPTION
## 🗣 Description

This PR removes the bit that was removing all kernel headers.

## 💭 Motivation and Context

The newer kernel is still the one running, so if any later packages need to build kernel modules they will want to be able to build them for the newer kernel as well as the one that will be used after reboot.

This is why [this AMI build](https://github.com/cisagov/guacamole-packer/runs/968371929) failed.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
