### PR TITLE
Configure grub to use the desired kernel

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Run update-grub
+  command:
+    cmd: /usr/sbin/update-grub

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -15,7 +15,7 @@
     - name: Group hosts by OS distribution
       group_by:
         key: os_{{ ansible_distribution }}_{{ ansible_distribution_version }}
-- name: Wait for systemd to complete initialization (Debian)
+- name: Install the latest kernel (Debian 10)
   hosts: os_Debian_10
   tasks:
     - name: Install aptitude (Debian 10)

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,9 +1,0 @@
----
-- src: https://github.com/cisagov/ansible-role-pip
-  name: pip
-- src: https://github.com/cisagov/ansible-role-python
-  name: python
-- src: https://github.com/cisagov/ansible-role-remove-python2
-  name: remove_python2
-- src: https://github.com/cisagov/ansible-role-upgrade
-  name: upgrade

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,12 +19,12 @@ def test_debian_kernel_held(host):
         host.system_info.distribution == "debian"
         and host.system_info.codename == "buster"
     ):
-        assert set(host.file("/boot").listdir()) == {
+        assert {
             "System.map-4.19.0-9-cloud-amd64",
             "config-4.19.0-9-cloud-amd64",
             "initrd.img-4.19.0-9-cloud-amd64",
             "vmlinuz-4.19.0-9-cloud-amd64",
-        }
+        }.issubset(set(host.file("/boot").listdir()))
 
 
 @pytest.mark.parametrize("pkg", ["aptitude"])

--- a/tasks/Debian_10_hold_kernel.yml
+++ b/tasks/Debian_10_hold_kernel.yml
@@ -5,19 +5,36 @@
     force_apt_get: yes
     update_cache: yes
 
-# On Debian, the 4.19.132-1 kernel is randomly locking up on us, while
-# the 4.19.118-2 kernel worked just fine.  Until we can determine the
-# exact reason for the failure and verify that it has been fixed, we
-# will install the 4.19.118-2 kernel and hold that package.
+# On Debian 10, the 4.19.132-1 kernel is randomly locking up on us,
+# while the 4.19.118-2 kernel worked just fine.  By turning on kdump
+# functionality, we were able to verify that the cause of the lockups
+# is exactly what is discussed in these links: *
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966846 *
+# https://lkml.org/lkml/2020/7/20/883
+#
+# Until we can verify that the kernel bug has been fixed, we will
+# install the 4.19.118-2 kernel and reconfigure grub to set it as the
+# default kernel.
 - name: Install specific version of kernel (Debian)
   apt:
     name:
       - linux-headers-4.19.0-9-cloud-amd64
       - linux-image-4.19.0-9-cloud-amd64
-- name: Hold the kernel so that it is not upgraded via apt-get upgrade
-  dpkg_selections:
-    name: "{{ item }}"
-    selection: hold
-  loop:
-    - linux-headers-4.19.0-9-cloud-amd64
-    - linux-image-4.19.0-9-cloud-amd64
+- name: Examine /etc/default/grub
+  stat:
+    path: /etc/default/grub
+  register: etc_default_grub
+- name: >
+    Make the kernel we just installed the default kernel in grub,
+    if grub is installed
+  lineinfile:
+    path: /etc/default/grub
+    regexp: ^GRUB_DEFAULT=
+    line: >
+      GRUB_DEFAULT="Advanced options for Debian GNU/Linux>
+      Debian GNU/Linux, with Linux 4.19.0-9-cloud-amd64"
+    backrefs: yes
+  when:
+    - etc_default_grub.stat.exists
+  notify:
+    - Run update-grub

--- a/tasks/Debian_10_hold_kernel.yml
+++ b/tasks/Debian_10_hold_kernel.yml
@@ -9,13 +9,6 @@
 # the 4.19.118-2 kernel worked just fine.  Until we can determine the
 # exact reason for the failure and verify that it has been fixed, we
 # will install the 4.19.118-2 kernel and hold that package.
-- name: Remove all installed kernels (Debian)
-  apt:
-    name:
-      - linux-image-*
-    state: absent
-  tags:
-    - molecule-idempotence-notest
 - name: Install specific version of kernel (Debian)
   apt:
     name:

--- a/tasks/Debian_10_hold_kernel.yml
+++ b/tasks/Debian_10_hold_kernel.yml
@@ -1,10 +1,4 @@
 ---
-- name: Install aptitude (Debian)
-  apt:
-    name: aptitude
-    force_apt_get: yes
-    update_cache: yes
-
 # On Debian 10, the 4.19.132-1 kernel is randomly locking up on us,
 # while the 4.19.118-2 kernel worked just fine.  By turning on kdump
 # functionality, we were able to verify that the cause of the lockups
@@ -31,8 +25,8 @@
     path: /etc/default/grub
     regexp: ^GRUB_DEFAULT=
     line: >
-      GRUB_DEFAULT="Advanced options for Debian GNU/Linux>
-      Debian GNU/Linux, with Linux 4.19.0-9-cloud-amd64"
+      GRUB_DEFAULT="Advanced options for Debian GNU/Linux>Debian GNU/Linux,
+      with Linux 4.19.0-9-cloud-amd64"
     backrefs: yes
   when:
     - etc_default_grub.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,4 @@
 ---
-# tasks file for upgrade
-
-# On Debian 10, the 4.19.132-1 kernel is randomly locking up on us,
-# while the 4.19.118-2 kernel worked just fine.  Until we can
-# determine the exact reason for the failure and verify that it has
-# been fixed, we will install the 4.19.118-2 kernel and hold that
-# package.
-#
-# Note that this is done _only_ for version 10 of the Debian
-# distribution and not for other distributions in the Debian family.
-- name: Hold kernel for Debian distribution
-  include: Debian_10_hold_kernel.yml
-  when:
-    - ansible_distribution == "Debian"
-    - ansible_distribution_version == "10"
-
 - name: Load tasks file with install tasks based on the OS type
   include: "{{ lookup('first_found', params) }}"
   vars:
@@ -28,3 +12,22 @@
         - "{{ ansible_os_family | regex_replace('[ /]', '_') }}.yml"
       paths:
         - "{{ role_path }}/tasks"
+
+# On Debian 10, the 4.19.132-1 kernel is randomly locking up on us,
+# while the 4.19.118-2 kernel worked just fine.  By turning on kdump
+# functionality, we were able to verify that the cause of the lockups
+# is exactly what is discussed in these links: *
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966846 *
+# https://lkml.org/lkml/2020/7/20/883
+#
+# Until we can verify that the kernel bug has been fixed, we will
+# install the 4.19.118-2 kernel and reconfigure grub to set it as the
+# default kernel.
+#
+# Note that this is done _only_ for version 10 of the Debian
+# distribution and not for other distributions in the Debian family.
+- name: Hold kernel for Debian distribution
+  include: Debian_10_hold_kernel.yml
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_distribution_version == "10"


### PR DESCRIPTION
## 🗣 Description

This pull requests modifies this Ansible role to configure `grub` to use the desired kernel.

## 💭 Motivation and Context

My attempts to build a Guacamole AMI that runs an older kernel in #11, #12, and #13 all failed for various reasons; therefore, I decided to take a more heavy-handed approach here.

## 🧪 Testing

I used these changes to successfully build a Guacamole AMI for staging that boots into the desired kernel.  This AMI is currently deployed to env1 in staging.

## 📷 Screenshots (if appropriate)

![screenshot](https://user-images.githubusercontent.com/5521725/89937764-898d0100-dbe3-11ea-8556-1d1a3732fc71.png)

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
