### PR TITLE
Cleanup

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -8,4 +8,4 @@
     update_cache: yes
 - name: Upgrade all packages (Debian)
   apt:
-    upgrade: dist
+    upgrade: full

--- a/tasks/Kali_GNU_Linux.yml
+++ b/tasks/Kali_GNU_Linux.yml
@@ -1,5 +1,0 @@
----
-# tasks file for upgrade (Kali)
-
-- name: Use Debian tasks for Kali
-  include_tasks: Debian.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,12 +4,9 @@
   vars:
     params:
       files:
-        # Add regex_replace() filters to remove spaces and
-        # slashes. This allows the OS family/distribution for Kali,
-        # "Kali GNU/Linux", to be easily mapped to a vars file.
-        - "{{ ansible_distribution | regex_replace('[ /]', '_') }}_{{ ansible_distribution_version }}.yml"
-        - "{{ ansible_distribution | regex_replace('[ /]', '_') }}.yml"
-        - "{{ ansible_os_family | regex_replace('[ /]', '_') }}.yml"
+        - "{{ ansible_distribution }}_{{ ansible_distribution_version }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
       paths:
         - "{{ role_path }}/tasks"
 


### PR DESCRIPTION
## 🗣 Description

This pull request updates this Ansible role in a few spots.  It removes some now-unnecessary code and switches the `upgrade` parameter for the `apt` Ansible module from `dist` to `full`.  The latter probably makes no difference, but `full` appears to be preferred now.

## 💭 Motivation and Context

I was looking at this Ansible role while debugging [a failed AMI build](https://github.com/cisagov/kali-packer/runs/1329005857?check_suite_focus=true), and I realized that it could use some updating.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Clean up

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
