### PR TITLE
Use the detected package manager for RedHat-based platforms

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,7 +1,17 @@
 ---
 # tasks file for upgrade (RedHat)
 
-- name: Upgrade all packages (RedHat)
+- name: Upgrade all packages (RedHat) (dnf)
+  ansible.builtin.dnf:
+    name: '*'
+    # ansible-lint generates a warning that "package installs should
+    # not use latest" here, but this is one place where we want to use
+    # it.
+    state: latest  # noqa 403
+    update_cache: yes
+  when: ansible_pkg_mgr == "dnf"
+
+- name: Upgrade all packages (RedHat) (yum)
   ansible.builtin.yum:
     name: '*'
     # ansible-lint generates a warning that "package installs should
@@ -9,3 +19,4 @@
     # it.
     state: latest  # noqa 403
     update_cache: yes
+  when: ansible_pkg_mgr == "yum"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the tasks file for RedHat-based platforms to respect the detected package manager when updating installed packages.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Historically `yum` was the default package manager for RedHat-based platforms but more recent releases/distributions have moved to `dnf`. Since the [`ansible.builtin.package` module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html) uses the detected package manager it makes sense to update installed packages using the same package manager.

As an example when checking the value of `ansible_pkg_mgr` across common RedHat-based platforms:

```log
ok: [amazonlinux2] => {
    "msg": "yum"
}
ok: [amazonlinux2022] => {
    "msg": "yum"
}
ok: [centos7] => {
    "msg": "yum"
}
ok: [fedora34] => {
    "msg": "dnf"
}
ok: [fedora35] => {
    "msg": "dnf"
}
ok: [fedora36] => {
    "msg": "dnf"
}
ok: [rhel7] => {
    "msg": "yum"
}
ok: [rhel8] => {
    "msg": "dnf"
}
ok: [rockylinux8] => {
    "msg": "dnf"
}
ok: [rockylinux9] => {
    "msg": "dnf"
}
```

**Note**: Amazon Linux 2022 incorrectly defaults to `yum` because we are still using Ansible 5. It correctly uses `dnf` in Ansible 6.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
