### PR TITLE
Prefer dnf to yum

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/tasks/Amazon_NA.yml
+++ b/tasks/Amazon_NA.yml
@@ -1,0 +1,9 @@
+---
+- name: Upgrade all packages (Amazon Linux)
+  ansible.builtin.yum:
+    name: '*'
+    # ansible-lint generates a warning that "package installs should
+    # not use latest" here, but this is one place where we want to use
+    # it.
+    state: latest  # noqa 403
+    update_cache: yes

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for upgrade (Debian)
-
 - name: Install aptitude (Debian)
   ansible.builtin.apt:
     name: aptitude

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for upgrade (RedHat)
-
 - name: Upgrade all packages (RedHat)
   ansible.builtin.dnf:
     name: '*'

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 # tasks file for upgrade (RedHat)
 
 - name: Upgrade all packages (RedHat)
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: '*'
     # ansible-lint generates a warning that "package installs should
     # not use latest" here, but this is one place where we want to use


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible code to prefer `dnf` to `yum` for RedHat systems other than Amazon Linux.

## 💭 Motivation and context ##

`dnf` is the modern replacement for `yum`.

On a sad note, Amazon Linux 2 is too old to support `dnf`; therefore, we continue to use `yum` for that platform.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.