### PR TITLE
Select tasks to run based on detected package manager, not OS

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -14,22 +14,15 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 @pytest.mark.parametrize("pkg", ["aptitude"])
-def test_debian_packages(host, pkg):
-    """Test that appropriate packages were installed on Debian."""
-    if (
-        host.system_info.distribution == "debian"
-        or host.system_info.distribution == "kali"
-    ):
+def test_apt_packages(host, pkg):
+    """Test that appropriate packages were installed on apt-based systems."""
+    if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
         assert host.package(pkg).is_installed
 
 
-def test_debian_updated(host):
-    """Test that Debian instances were updated."""
-    if (
-        host.system_info.distribution == "debian"
-        or host.system_info.distribution == "kali"
-    ):
-        print(host.file("/var/lib/apt/lists").mtime)
+def test_apt_updated(host):
+    """Test that apt-based systems were updated."""
+    if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
         # Make sure that the instance was updated in the last 20
         # minutes.
         assert (
@@ -39,12 +32,9 @@ def test_debian_updated(host):
 
 # This test can fail if there were no updates to install.
 @pytest.mark.xfail
-def test_redhat_updated_time(host):
-    """Test that RedHat instances were updated."""
-    if (
-        host.system_info.distribution == "amzn"
-        or host.system_info.distribution == "fedora"
-    ):
+def test_yum_updated_time(host):
+    """Test that yum-based instances were updated."""
+    if host.system_info.distribution in ["amzn"]:
         last_update = datetime.datetime.strptime(
             host.run(
                 "yum --quiet history list | cut --delimiter='|' --fields=3-4 | grep -F U | cut --delimiter='|' --fields=1 | head --lines=1"
@@ -56,12 +46,9 @@ def test_redhat_updated_time(host):
         assert (datetime.datetime.now() - last_update).total_seconds() <= 20 * 60
 
 
-def test_redhat_updated_command_output(host):
-    """Test that RedHat instances were updated."""
-    if (
-        host.system_info.distribution == "amzn"
-        or host.system_info.distribution == "fedora"
-    ):
+def test_yum_updated_command_output(host):
+    """Test that yum-based instances were updated."""
+    if host.system_info.distribution in ["amzn"]:
         yum_output = host.run("yum update")
         # If the update succeeded or there was nothing to update
         assert (

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -50,7 +50,7 @@ def test_yum_updated_command_output(host):
     """Test that yum-based instances were updated."""
     if host.system_info.distribution in ["amzn"]:
         yum_output = host.run("yum update")
-        # If the update succeeded or there was nothing to update
+        # There should be nothing to update.
         assert "No packages marked for update" in yum_output.stdout
 
 
@@ -74,5 +74,5 @@ def test_dnf_updated_command_output(host):
     """Test that dnf-based instances were updated."""
     if host.system_info.distribution in ["fedora"]:
         dnf_output = host.run("dnf update")
-        # If the update succeeded or there was nothing to update
+        # There should be nothing to update.
         assert "Nothing to do." in dnf_output.stdout

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -1,9 +1,9 @@
 ---
-- name: Install aptitude (Debian)
+- name: Install aptitude
   ansible.builtin.apt:
     name: aptitude
     force_apt_get: yes
     update_cache: yes
-- name: Upgrade all packages (Debian)
+- name: Upgrade all packages
   ansible.builtin.apt:
     upgrade: full

--- a/tasks/dnf.yml
+++ b/tasks/dnf.yml
@@ -1,6 +1,6 @@
 ---
-- name: Upgrade all packages (Amazon Linux)
-  ansible.builtin.yum:
+- name: Upgrade all packages
+  ansible.builtin.dnf:
     name: '*'
     # ansible-lint generates a warning that "package installs should
     # not use latest" here, but this is one place where we want to use

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,9 @@
 ---
-- name: Load tasks file with install tasks based on the OS type
+- name: Load tasks file with install tasks based on the detected package manager
   ansible.builtin.include_tasks: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
-        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_pkg_mgr }}.yml"
       paths:
         - "{{ role_path }}/tasks"

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -1,6 +1,6 @@
 ---
-- name: Upgrade all packages (RedHat)
-  ansible.builtin.dnf:
+- name: Upgrade all packages
+  ansible.builtin.yum:
     name: '*'
     # ansible-lint generates a warning that "package installs should
     # not use latest" here, but this is one place where we want to use


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to select the tasks to run based on the detected package manager instead of the OS.

## 💭 Motivation and context ##

This is a slight improvement to what @mcdonnnj did in #49.  We will need these changes shortly, since Amazon Linux 2023 was just officially released.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.