### PR TITLE
Minor formatting cleanup

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -1,9 +1,10 @@
 ---
 - name: Install aptitude
   ansible.builtin.apt:
-    name: aptitude
     force_apt_get: true
+    name: aptitude
     update_cache: true
+
 - name: Upgrade all packages
   ansible.builtin.apt:
     upgrade: full

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -2,8 +2,8 @@
 - name: Install aptitude
   ansible.builtin.apt:
     name: aptitude
-    force_apt_get: yes
-    update_cache: yes
+    force_apt_get: true
+    update_cache: true
 - name: Upgrade all packages
   ansible.builtin.apt:
     upgrade: full

--- a/tasks/dnf.yml
+++ b/tasks/dnf.yml
@@ -6,4 +6,4 @@
     # not use latest" here, but this is one place where we want to use
     # it.
     state: latest  # noqa package-latest
-    update_cache: yes
+    update_cache: true


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does some minor formatting cleanup including preferring `true`/`false` to `yes`/`no` in YAML files and ensuring module parameters are sorted alphabetically.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The switch from `yes`/`no` to `true`/`false` was made upstream in https://github.com/cisagov/skeleton-ansible-role/pull/157 but when https://github.com/cisagov/ansible-role-upgrade/pull/59 was merged it was not propagated to the role's task files. We prefer alphabetization when possible so that is just keeping with our best practices.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
