### PR TITLE
Install the `kernel-core` package separately on Fedora

### DIFF
--- a/tasks/dnf.yml
+++ b/tasks/dnf.yml
@@ -1,9 +1,28 @@
 ---
 - name: Upgrade all packages
-  ansible.builtin.dnf:
-    name: '*'
-    # ansible-lint generates a warning that "package installs should
-    # not use latest" here, but this is one place where we want to use
-    # it.
-    state: latest  # noqa package-latest
-    update_cache: true
+  block:
+    # TODO: Remove the following block when that becomes possible.
+    # See #64 for more details.
+    - name: Upgrade the kernel-core package separately on Fedora
+      when: ansible_distribution == "Fedora"
+      block:
+        - name: Update package cache (Fedora)
+          ansible.builtin.dnf:
+            update_cache: true
+        - name: Upgrade the kernel-core package separately (Fedora)
+          ansible.builtin.dnf:
+            name: "{{ item }}"
+            # ansible-lint generates a warning that "package installs
+            # should not use latest" here, but this is one place where
+            # we want to use it.
+            state: latest  # noqa package-latest
+          loop:
+            - kernel-core
+    - name: Upgrade all packages
+      ansible.builtin.dnf:
+        name: "*"
+        # ansible-lint generates a warning that "package installs
+        # should not use latest" here, but this is one place where we
+        # want to use it.
+        state: latest  # noqa package-latest
+        update_cache: true


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the role to upgrade the `kernel-core` package by itself, then upgrade all other packages when run on Fedora.

## 💭 Motivation and context ##

Fedora currently has a problem where the `kernel-core` package's post-install hooks error out when it is upgraded along with too many other packages. Upgrading the `kernel-core` by itself, then upgrading all the other packages, is a workaround.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.