### PR TITLE
Support the `dnf5` package manager

### DIFF
--- a/tasks/dnf5.yml
+++ b/tasks/dnf5.yml
@@ -1,0 +1,28 @@
+---
+- name: Upgrade all packages
+  block:
+    # TODO: Remove the following block when that becomes possible.
+    # See #64 for more details.
+    - name: Upgrade the kernel-core package separately on Fedora
+      when: ansible_distribution == "Fedora"
+      block:
+        - name: Update package cache (Fedora)
+          ansible.builtin.dnf5:
+            update_cache: true
+        - name: Upgrade the kernel-core package separately (Fedora)
+          ansible.builtin.dnf5:
+            name: "{{ item }}"
+            # ansible-lint generates a warning that "package installs
+            # should not use latest" here, but this is one place where
+            # we want to use it.
+            state: latest  # noqa package-latest
+          loop:
+            - kernel-core
+    - name: Upgrade all packages
+      ansible.builtin.dnf5:
+        name: "*"
+        # ansible-lint generates a warning that "package installs
+        # should not use latest" here, but this is one place where we
+        # want to use it.
+        state: latest  # noqa package-latest
+        update_cache: true


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds support for the `dnf5` package manager.

## 💭 Motivation and context ##

We are adding support for Fedora 41 soon in cisagov/skeleton-ansible-role#207, and `ansible` identifies the package manager for that platform as `dnf5`, so we need to support it.

## 🧪 Testing ##

All automated tests pass.  These changes are also [tested](https://github.com/cisagov/skeleton-ansible-role/actions/runs/11749218071) as part of cisagov/skeleton-ansible-role#207.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.